### PR TITLE
Fix race condition in updater thread.

### DIFF
--- a/src/UpdaterCheck.cpp
+++ b/src/UpdaterCheck.cpp
@@ -132,7 +132,7 @@ void HandleOpenAromaUpdater(WUPSButtonCombo_ControllerTypes, WUPSButtonCombo_Com
     }
     NotificationModule_FinishDynamicNotification(sAromaUpdateHandle, 0.5f);
     sAromaUpdateHandle = 0;
-    if (const RPXLoaderStatus err = RPXLoader_LaunchHomebrew(sAromaUpdaterPath.data()); err == RPX_LOADER_RESULT_SUCCESS) {
+    if (const RPXLoaderStatus err = RPXLoader_LaunchHomebrew(sAromaUpdaterPath.c_str()); err == RPX_LOADER_RESULT_SUCCESS) {
         sUpdaterLaunched = true;
     } else {
         DEBUG_FUNCTION_LINE_ERR("RPXLoader_LaunchHomebrew failed: %s", RPXLoader_GetStatusStr(err));

--- a/src/UpdaterCheck.cpp
+++ b/src/UpdaterCheck.cpp
@@ -49,9 +49,7 @@ void RemoveButtonComboHandles(NotificationModuleHandle, void *) {
 }
 
 void StopUpdaterCheckThread() {
-    if (sCheckUpdateThread) {
-        sCheckUpdateThread.reset();
-    }
+    sCheckUpdateThread.reset();
     RemoveButtonComboHandles(0, nullptr);
 }
 


### PR DESCRIPTION
This fixes a race condition, where the updater thread was reading `sCheckUpdateThread` (and assuming it wasn't null) while it was being assigned in the parent thread. The intended usage for `std::jthread` is for the thread function to receive a `std::stop_token` as the first argument, eliminating the need to reach into the `std::jthread` object.

This also changes `sCheckUpdateThread` to `std::optional`, avoiding one extra heap allocation, costing only 8 bytes.

There are also some minor cleanup changes I did while I was bored looking for the bug.